### PR TITLE
fix missing resource

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -99,6 +99,7 @@
   "views": [
     {
       "name": "graph",
+      "resources": ["monthly"],
       "spec": {
         "group": "Date",
         "series": [


### PR DESCRIPTION
Fix missing resource field for gold prices dataset

## Error
![image](https://github.com/datasets/gold-prices/assets/67981832/0b6fa346-c609-4287-8304-76190f22fa42)

## After the fix 
![image](https://github.com/datasets/gold-prices/assets/67981832/848e788f-d094-4c1a-91fe-8e3187752062)

