### PR TITLE
Fix README and datapackage.json metadata errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ python scripts/process.py
 ### Notes from the Sources
 
 * Currently data has been sourced using multiple datasets:
-  - **Historical data (1833–1959):** Timothy Green's Historical Gold Price Table, originally hosted at the National Mining Association. Note: as of 2026 this PDF requires a login to download; the update script handles this gracefully by skipping the PDF merge if the file is unavailable.
+  - **Historical data (1833–1959):** Timothy Green's Historical Gold Price Table, originally hosted at the National Mining Association. Note: as of 2026 this PDF requires a login to download; the update script handles this gracefully by skipping the PDF merge if the file is unavailable. Because only annual figures exist for this period, the monthly and monthly-processed files repeat the annual average price for every month of the year (i.e. all 12 months in 1890 carry the same value).
   - **Modern data (1960–present):** [World Bank Commodity Markets](https://www.worldbank.org/en/research/commodity-markets), which is regularly updated and provides comprehensive, up-to-date data on a wide range of commodity prices.
 
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 <a className="gh-badge" href="https://datahub.io/core/gold-prices"><img src="https://badgen.net/badge/icon/View%20on%20datahub.io/orange?icon=https://datahub.io/datahub-cube-badge-icon.svg&label&scale=1.25" alt="badge" /></a>
 
-Monthly gold prices in USD since 1833 (sourced from the World Gold Council). The data is derived from historical records compiled by Timothy Green and supplemented by data provided by the World Bank.
+Monthly gold prices in USD since 1833. Historical data (1833–1959) is sourced from records compiled by Timothy Green; data from 1960 to the present is sourced from the World Bank Commodity Markets ("Pink Sheet").
 
 ## Data
 
-* [Worldbank-Commodity-Market](https://www.worldbank.org/en/research/commodity-markets)
+* [World Bank Commodity Markets](https://www.worldbank.org/en/research/commodity-markets)
 
 ## Preparation
 
-You will need Python 3.6 or greater and dataflows library to run the script
+You will need Python 3.11 or greater to run the script.
 
 To update the data run the process script locally:
 
@@ -20,15 +20,15 @@ python scripts/process.py
 
 ### Notes from the Sources
 
-* Currently data has been sourced using multiple datasets, 
-  - This one is presented by Timothy Green Historical Gold Price Table the description is available [historical-data-1883](https://nma.org/wp-content/uploads/2016/09/historic_gold_prices_1833_pres.pdf) and the data used up until 1960 year.
-  - The second dataset was obtained from the [Worldbank-Commodity-Market](https://www.worldbank.org/en/research/commodity-markets), which is regularly updated and provides comprehensive, up-to-date data on a wide range of commodity prices. This dataset includes historical data dating back to 1960, extending up to the present day.
+* Currently data has been sourced using multiple datasets:
+  - **Historical data (1833–1959):** Timothy Green's Historical Gold Price Table, originally hosted at the National Mining Association. Note: as of 2026 this PDF requires a login to download; the update script handles this gracefully by skipping the PDF merge if the file is unavailable.
+  - **Modern data (1960–present):** [World Bank Commodity Markets](https://www.worldbank.org/en/research/commodity-markets), which is regularly updated and provides comprehensive, up-to-date data on a wide range of commodity prices.
 
 
 ## Automation
 
-This dataset is automatically updates every month on the datahub.io site: http://datahub.io/core/gold-prices
+This dataset is automatically updated daily via GitHub Actions. View the dataset on DataHub: https://datahub.io/core/gold-prices
 
 ## License
 
-The maintainers have licensed under the Public Domain Dedication and License. The source at the Bundesbank indicates no obvious restrictions on the data and the amount means that database rights are doubtful.
+The maintainers have licensed this dataset under the Public Domain Dedication and License. The World Bank data is freely available with no obvious restrictions; the Timothy Green historical records similarly carry no known restrictions.

--- a/datapackage.json
+++ b/datapackage.json
@@ -42,7 +42,6 @@
           {
             "name": "Date",
             "type": "date",
-            "format": "default",
             "description": "First day of the month in YYYY-MM-DD format (ISO 8601)."
           },
           {
@@ -66,13 +65,11 @@
           {
             "name": "Date",
             "type": "year",
-            "format": "default",
             "description": "Year of the observation (YYYY)."
           },
           {
             "name": "Price",
             "type": "number",
-            "format": "default",
             "description": "Annual average gold price in USD per troy ounce."
           }
         ],
@@ -94,13 +91,11 @@
           {
             "name": "Date",
             "type": "yearmonth",
-            "format": "default",
             "description": "Year and month of the observation in YYYY-MM format."
           },
           {
             "name": "Price",
             "type": "number",
-            "format": "default",
             "description": "Gold price in USD per troy ounce."
           }
         ],

--- a/datapackage.json
+++ b/datapackage.json
@@ -1,11 +1,11 @@
 {
   "homepage": "https://www.worldbank.org/",
+  "description": "Monthly and annual gold prices in USD per troy ounce from 1833 to present. Historical data (1833–1959) is sourced from records compiled by Timothy Green; data from 1960 onward is sourced from the World Bank Commodity Markets portal.",
   "licenses": [
     {
-      "id": "odc-pddl",
-      "name": "public_domain_dedication_and_license",
-      "url": "https://opendatacommons.org/licenses/pddl/1-0/",
-      "version": "1.0"
+      "name": "ODC-PDDL-1.0",
+      "path": "https://opendatacommons.org/licenses/pddl/1-0/",
+      "title": "Open Data Commons Public Domain Dedication and License"
     }
   ],
   "name": "gold-prices",
@@ -33,14 +33,23 @@
   "resources": [
     {
       "name": "monthly-processed",
-      "description": "Monthly gold prices in USD per troy ounce from 1833 to present, with dates formatted as ISO 8601 full dates (YYYY-MM-DD).",
+      "description": "Monthly gold prices in USD per troy ounce from 1833 to present, with dates formatted as ISO 8601 full dates (YYYY-MM-DD). Rows from 1833 to 1959 carry the annual average price repeated for every month of the year, as no true monthly readings exist for that period.",
       "path": "data/monthly-processed.csv",
       "format": "csv",
       "mediatype": "text/csv",
       "schema": {
         "fields": [
-          { "name": "Date", "type": "date", "format": "any" },
-          { "name": "Price", "type": "number", "description": "Gold price in USD per troy ounce" }
+          {
+            "name": "Date",
+            "type": "date",
+            "format": "default",
+            "description": "First day of the month in YYYY-MM-DD format (ISO 8601)."
+          },
+          {
+            "name": "Price",
+            "type": "number",
+            "description": "Gold price in USD per troy ounce."
+          }
         ]
       }
     },
@@ -55,14 +64,16 @@
       "schema": {
         "fields": [
           {
-            "format": "default",
             "name": "Date",
-            "type": "year"
+            "type": "year",
+            "format": "default",
+            "description": "Year of the observation (YYYY)."
           },
           {
-            "format": "default",
             "name": "Price",
-            "type": "number"
+            "type": "number",
+            "format": "default",
+            "description": "Annual average gold price in USD per troy ounce."
           }
         ],
         "missingValues": [
@@ -75,20 +86,22 @@
       "format": "csv",
       "mediatype": "text/csv",
       "name": "monthly",
-      "description": "Monthly gold prices in USD per troy ounce from 1833 to present, with dates in YYYY-MM format.",
+      "description": "Monthly gold prices in USD per troy ounce from 1833 to present, with dates in YYYY-MM format. Rows from 1833 to 1959 carry the annual average price repeated for every month of the year, as no true monthly readings exist for that period.",
       "path": "data/monthly.csv",
       "profile": "tabular-data-resource",
       "schema": {
         "fields": [
           {
-            "format": "default",
             "name": "Date",
-            "type": "yearmonth"
+            "type": "yearmonth",
+            "format": "default",
+            "description": "Year and month of the observation in YYYY-MM format."
           },
           {
-            "format": "default",
             "name": "Price",
-            "type": "number"
+            "type": "number",
+            "format": "default",
+            "description": "Gold price in USD per troy ounce."
           }
         ],
         "missingValues": [

--- a/datapackage.json
+++ b/datapackage.json
@@ -4,7 +4,7 @@
     {
       "id": "odc-pddl",
       "name": "public_domain_dedication_and_license",
-      "url": "http://opendatacommons.org/licenses/pddl/1.0/",
+      "url": "https://opendatacommons.org/licenses/pddl/1-0/",
       "version": "1.0"
     }
   ],
@@ -45,8 +45,7 @@
       }
     },
     {
-      "dpp:streaming": true,
-      "encoding": "utf-8-sig",
+      "encoding": "utf-8",
       "format": "csv",
       "mediatype": "text/csv",
       "name": "annual",
@@ -58,7 +57,7 @@
           {
             "format": "default",
             "name": "Date",
-            "type": "yearmonth"
+            "type": "year"
           },
           {
             "format": "default",
@@ -100,9 +99,14 @@
   ],
   "sources": [
     {
-      "name": "worldbank-gold-prices",
+      "name": "worldbank-commodity-markets",
       "path": "https://www.worldbank.org/en/research/commodity-markets",
-      "title": "Worldbank gold prices"
+      "title": "World Bank Commodity Markets (Pink Sheet)"
+    },
+    {
+      "name": "timothy-green-historical-gold-prices",
+      "path": "https://nma.org/wp-content/uploads/2016/09/historic_gold_prices_1833_pres.pdf",
+      "title": "Timothy Green Historical Gold Price Table (National Mining Association)"
     }
   ],
   "title": "Gold Prices",


### PR DESCRIPTION
## Summary

| # | File | Problem | Fix |
|---|------|---------|-----|
| 1 | README | sourced from the World Gold Council — WGC is not a source used in the script | Corrected to World Bank + Timothy Green |
| 2 | README | Python 3.6 or greater and dataflows library — dataflows not used; workflow pins 3.11 | Updated to Python 3.11, dropped dataflows mention |
| 3 | README | NMA PDF URL now 302-redirects to a login page | Added note; script try/except already handles this |
| 4 | README | automatically updates every month — workflow cron is daily | Fixed to daily |
| 5 | README | The source at the Bundesbank — Bundesbank has nothing to do with gold prices | Replaced with accurate World Bank reference |
| 6 | README | Pre-1960 monthly data quirk undocumented | Added note: 1833–1959 rows repeat the annual average for every month |
| 7 | datapackage.json | No package-level description | Added |
| 8 | datapackage.json | licenses: url instead of path, no title, non-SPDX name | Renamed to path, added title, set name to ODC-PDDL-1.0 |
| 9 | datapackage.json | annual Date type yearmonth — actual data is YYYY integers | Changed to year |
| 10 | datapackage.json | dpp:streaming: true on annual resource — legacy dataflows artifact | Removed |
| 11 | datapackage.json | License URL http:// | Updated to https:// with canonical path |
| 12 | datapackage.json | Only World Bank in sources | Added Timothy Green/NMA entry |
| 13 | datapackage.json | All Date and Price fields missing description | Added descriptions to every field in all three resources |